### PR TITLE
fix: update dart version in release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: 'Setup Dart'
         uses: dart-lang/setup-dart@v1.3
         with:
-          sdk: 2.17.0
+          sdk: 2.18.2
 
       - name: 'Setup credentials'
         run: |


### PR DESCRIPTION
fix the release action for 1.1.0 release

- changes the Dart version
- changes the minor version identifier for git-version 