### PR TITLE
fix: sync pub version and repo tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1
+
+* bump version for Dart Pub sync
+
 ## 1.1.0
 
 * new L0 Auth and L0 Storage APIs

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: tiki_sdk_dart
 description: The core implementation (pure dart) of TIKI's decentralized infrastructure plus abstractions to simplify the tokenization and application of data ownership, consent, and rewards. For new projects, we recommend one of our platform-specific SDKs. Same features. Much easier to implement.
-version: 1.1.0
+version: 1.1.1
 homepage: https://mytiki.com
 documentation: https://docs.mytiki.com
 repository: https://github.com/tiki/tiki-sdk-dart


### PR DESCRIPTION
With the release tests, the tag 0.0.1 was published as 1.1.0 to pub.

To fix that and keep versions in sync, this PR bumps version to 1.1.1