### PR TITLE
fix: move release action to docs and pass the tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
   release:
     if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/')
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.version.outputs.version }}
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3
@@ -50,11 +52,6 @@ jobs:
       - name: 'Publish'
         run: dart pub publish -f
 
-      - name: Create a Release
-        uses: ncipollo/release-action@v1
-        with:
-          tag: ${{steps.version.outputs.version }}
-
   docs:
     runs-on: ubuntu-latest
     needs: [ release ]
@@ -72,5 +69,7 @@ jobs:
         with:
           rdme: docs doc/ref --key=${{ secrets.README_API_KEY }}
 
-      - name: Release
-        uses: softprops/action-gh-release@v1
+      - name: Create a Release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ needs.release.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   release:
     if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/')
+    environment: Production
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.version.outputs.version }}


### PR DESCRIPTION
The trigger for the release action is not the tag creation. We need to pass the release version between release and docs jobs to create the release after the docs are published.

There is no need to relaunch 1.1.1 because just the last step failed, but the release was configured for the previous job.