### PR TITLE
2.0.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Check a new tag
         id: tag
         run: |
-          export TAG_VERSION=$(grep version pubspec.yaml |  awk -F  ': ' '/1/ {print $2}')
+          export TAG_VERSION=$(grep version pubspec.yaml |  awk -F  ': ' '{print $2}')
           echo "version=$TAG_VERSION" >> $GITHUB_OUTPUT
           echo $TAG_VERSION
           git tag $TAG_VERSION

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     environment: Production
     runs-on: ubuntu-latest
     outputs:
-      tag: ${{ steps.version.outputs.version }}
+      tag: ${{ steps.tag.outputs.version }}
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,17 +38,14 @@ jobs:
       - name: Run tests
         run: dart test
 
-      - name: Git version
-        id: version
-        uses: codacy/git-version@2.7.1
-        with:
-          release-branch: "main"
-          minor-identifier: "feat"
-
-      - name: Create a new tag
+      - name: Check a new tag
+        id: tag
         run: |
-          git tag ${{ steps.version.outputs.version }}
-          git push origin ${{ steps.version.outputs.version }}
+          export TAG_VERSION=$(grep version pubspec.yaml |  awk -F  ': ' '/1/ {print $2}')
+          echo "version=$TAG_VERSION" >> $GITHUB_OUTPUT
+          echo $TAG_VERSION
+          git tag $TAG_VERSION
+          git push origin $TAG_VERSION
 
       - name: 'Publish'
         run: dart pub publish -f

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,4 +53,4 @@ jobs:
       - name: Create a Release
         uses: ncipollo/release-action@v1
         with:
-          tag: ${{ steps.version.outputs.version }}
+          tag: ${{ steps.tag.outputs.version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Verify tag version
         id: tag
         run: |
-          export TAG_VERSION=$(grep version pubspec.yaml |  awk -F  ': ' '/1/ {print $2}')
+          export export TAG_VERSION=$(grep version pubspec.yaml |  awk -F  ': ' '{print $2}')
           echo "version=$TAG_VERSION" >> $GITHUB_OUTPUT
 
       - name: Confirm tag version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,10 +23,19 @@ jobs:
       - name: Run tests
         run: dart test --reporter github
 
-      - name: Static code analysis
+      - name: Dart Format
         run: |
           cd lib
           dart format . -o show --set-exit-if-changed
 
       - name: Check dart publish
         run: dart pub publish --dry-run
+
+      - name: Verify tag version
+        id: tag
+        run: |
+          export TAG_VERSION=$(grep version pubspec.yaml |  awk -F  ': ' '/1/ {print $2}')
+          echo "version=$TAG_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Confirm tag version
+        run: echo ${{ steps.tag.outputs.version }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Commit Changes
         run: |
+          git config --global user.email "action@github.com"
+          git config --global user.name "GH Action"
           git add pubspec.yaml
           git commit -m 'version bump'
           git push

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -36,7 +36,7 @@ jobs:
         uses: ietf-tools/semver-action@v1
         with:
           token: ${{ github.token }}
-          branch: ${{ steps.getpr.outputs.branch }}
+          branch: release/2.0.0
 
       - name: Set Version
         run: |

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Checkout PR
         env:

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -23,16 +23,20 @@ jobs:
           fetch-depth: 0
 
       - name: Checkout PR
+        id: getpr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr checkout ${{ github.event.pull_request.number }}
+        run: |
+          gh pr checkout ${{ github.event.pull_request.number }}
+          export PR_BRANCH=$(branch=git branch --show-current)
+          echo "branch=$PR_BRANCH" >> $GITHUB_OUTPUT
           
       - name: Get Version
         id: semver
         uses: ietf-tools/semver-action@v1
         with:
           token: ${{ github.token }}
-          branch: main
+          branch: ${{ steps.getpr.outputs.branch }}
 
       - name: Set Version
         run: |

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,37 @@
+name: Version
+
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Dart
+        uses: dart-lang/setup-dart@v1.3
+          
+      - name: Get Version
+        id: semver
+        uses: ietf-tools/semver-action@v1
+        with:
+          token: ${{ github.token }}
+          branch: main
+
+      - name: Set Version
+        run: |
+          sed -i 's/version:*.*.*/version: ${{ steps.semver.outputs.nextStrict }}/' pubspec.yaml
+
+      - name: Commit Changes
+        run: |
+          git add pubspec.yaml
+          git commit -m 'version bump'
+          git push

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -12,7 +12,6 @@ concurrency:
 jobs:
   version:
     if: startsWith(github.head_ref, 'release/')
-    environment: Production
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.semver.outputs.nextStrict }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -17,6 +17,9 @@ jobs:
     outputs:
       tag: ${{ steps.semver.outputs.nextStrict }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
       - name: Checkout PR
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  bump:
+  version:
     if: startsWith(github.head_ref, 'release/')
     environment: Production
     runs-on: ubuntu-latest

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -17,11 +17,10 @@ jobs:
     outputs:
       tag: ${{ steps.semver.outputs.nextStrict }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Setup Dart
-        uses: dart-lang/setup-dart@v1.3
+      - name: Checkout PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr checkout ${{ github.event.pull_request.number }}
           
       - name: Get Version
         id: semver
@@ -35,6 +34,8 @@ jobs:
           sed -i 's/version:*.*.*/version: ${{ steps.semver.outputs.nextStrict }}/' pubspec.yaml
 
       - name: Commit Changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config --global user.email "action@github.com"
           git config --global user.name "GH Action"

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -28,7 +28,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr checkout ${{ github.event.pull_request.number }}
-          export PR_BRANCH=$(branch=git branch --show-current)
+          export PR_BRANCH=$(git branch --show-current)
           echo "branch=$PR_BRANCH" >> $GITHUB_OUTPUT
           
       - name: Get Version
@@ -43,6 +43,7 @@ jobs:
           sed -i 's/version:*.*.*/version: ${{ steps.semver.outputs.nextStrict }}/' pubspec.yaml
 
       - name: Commit Changes
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -10,8 +10,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  bump:
+    if: startsWith(github.head_ref, 'release/')
+    environment: Production
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.semver.outputs.nextStrict }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: tiki_sdk_dart
 description: Create and enforce immutable data licensing records client-side. The core-implementation of TIKI's client-side infrastructure.
-version: 2.0.0
+version: 1.1.2
 homepage: https://mytiki.com
 documentation: https://docs.mytiki.com/docs/sdk-overview
 repository: https://github.com/tiki/tiki-sdk-dart


### PR DESCRIPTION
The codacy/git-version GH action wasn't detecting the versions correctly. Since Dart packages use pubspec.yaml for versioning by default, I have updated the release action to run just in "release/*" branches and to extract the version from pubspec.

This PR updates the release action and uses the branch name o trigger it.