### PR TITLE
fix: remove Uint64Lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
-### 2.1.2
+### 2.1.3
 
 - fix: Remove Uint64Lists for web compatability.
+
+### 2.1.2
+
+- fix: Move key generation to Key Storage interface for web compatability.
 
 ### 2.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+### 2.1.2
+
+- fix: Remove Uint64Lists for web compatability.
+
 ### 2.1.1
 
-* fix: Guard method should use plain text PTRs.
+- fix: Guard method should use plain text PTRs.
 
 ### 2.1.0
 **Expands the API to:**

--- a/doc/api/__404error.html
+++ b/doc/api/__404error.html
@@ -83,7 +83,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/index.html
+++ b/doc/api/index.html
@@ -127,7 +127,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/KeyStorage-class.html
+++ b/doc/api/tiki_sdk_dart/KeyStorage-class.html
@@ -284,7 +284,7 @@ See <a href="https://developer.mozilla.org/pt-BR/docs/Web/API/Web_Crypto_API">ht
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/KeyStorage/KeyStorage.html
+++ b/doc/api/tiki_sdk_dart/KeyStorage/KeyStorage.html
@@ -113,7 +113,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/KeyStorage/generate.html
+++ b/doc/api/tiki_sdk_dart/KeyStorage/generate.html
@@ -122,7 +122,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/KeyStorage/hashCode.html
+++ b/doc/api/tiki_sdk_dart/KeyStorage/hashCode.html
@@ -153,7 +153,7 @@ like <code>HashSet</code> or <code>HashMap</code>.</p>
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/KeyStorage/noSuchMethod.html
+++ b/doc/api/tiki_sdk_dart/KeyStorage/noSuchMethod.html
@@ -161,7 +161,7 @@ external dynamic noSuchMethod(Invocation invocation);</code></pre>
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/KeyStorage/operator_equals.html
+++ b/doc/api/tiki_sdk_dart/KeyStorage/operator_equals.html
@@ -152,7 +152,7 @@ the <a href="../../tiki_sdk_dart/KeyStorage/hashCode.html">hashCode</a> method a
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/KeyStorage/read.html
+++ b/doc/api/tiki_sdk_dart/KeyStorage/read.html
@@ -123,7 +123,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/KeyStorage/runtimeType.html
+++ b/doc/api/tiki_sdk_dart/KeyStorage/runtimeType.html
@@ -128,7 +128,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/KeyStorage/toString.html
+++ b/doc/api/tiki_sdk_dart/KeyStorage/toString.html
@@ -134,7 +134,7 @@ mainly for debugging or logging.</p>
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/KeyStorage/write.html
+++ b/doc/api/tiki_sdk_dart/KeyStorage/write.html
@@ -124,7 +124,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/LicenseRecord-class.html
+++ b/doc/api/tiki_sdk_dart/LicenseRecord-class.html
@@ -303,7 +303,7 @@ License Records.</p>
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/LicenseRecord/LicenseRecord.html
+++ b/doc/api/tiki_sdk_dart/LicenseRecord/LicenseRecord.html
@@ -127,7 +127,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/LicenseRecord/description.html
+++ b/doc/api/tiki_sdk_dart/LicenseRecord/description.html
@@ -126,7 +126,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/LicenseRecord/expiry.html
+++ b/doc/api/tiki_sdk_dart/LicenseRecord/expiry.html
@@ -126,7 +126,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/LicenseRecord/hashCode.html
+++ b/doc/api/tiki_sdk_dart/LicenseRecord/hashCode.html
@@ -156,7 +156,7 @@ like <code>HashSet</code> or <code>HashMap</code>.</p>
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/LicenseRecord/id.html
+++ b/doc/api/tiki_sdk_dart/LicenseRecord/id.html
@@ -126,7 +126,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/LicenseRecord/noSuchMethod.html
+++ b/doc/api/tiki_sdk_dart/LicenseRecord/noSuchMethod.html
@@ -164,7 +164,7 @@ external dynamic noSuchMethod(Invocation invocation);</code></pre>
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/LicenseRecord/operator_equals.html
+++ b/doc/api/tiki_sdk_dart/LicenseRecord/operator_equals.html
@@ -155,7 +155,7 @@ the <a href="../../tiki_sdk_dart/LicenseRecord/hashCode.html">hashCode</a> metho
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/LicenseRecord/runtimeType.html
+++ b/doc/api/tiki_sdk_dart/LicenseRecord/runtimeType.html
@@ -131,7 +131,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/LicenseRecord/terms.html
+++ b/doc/api/tiki_sdk_dart/LicenseRecord/terms.html
@@ -126,7 +126,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/LicenseRecord/title.html
+++ b/doc/api/tiki_sdk_dart/LicenseRecord/title.html
@@ -126,7 +126,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/LicenseRecord/toString.html
+++ b/doc/api/tiki_sdk_dart/LicenseRecord/toString.html
@@ -137,7 +137,7 @@ mainly for debugging or logging.</p>
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/LicenseRecord/uses.html
+++ b/doc/api/tiki_sdk_dart/LicenseRecord/uses.html
@@ -126,7 +126,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/LicenseUse-class.html
+++ b/doc/api/tiki_sdk_dart/LicenseUse-class.html
@@ -282,7 +282,7 @@ ECMAScript Compatible Regex (<code>'\\.mytiki\\.com'</code>)
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/LicenseUse/LicenseUse.fromMap.html
+++ b/doc/api/tiki_sdk_dart/LicenseUse/LicenseUse.fromMap.html
@@ -129,7 +129,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/LicenseUse/LicenseUse.html
+++ b/doc/api/tiki_sdk_dart/LicenseUse/LicenseUse.html
@@ -120,7 +120,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/LicenseUse/destinations.html
+++ b/doc/api/tiki_sdk_dart/LicenseUse/destinations.html
@@ -126,7 +126,7 @@ ECMAScript Compatible Regex (<code>'\\.mytiki\\.com'</code>)</p>
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/LicenseUse/hashCode.html
+++ b/doc/api/tiki_sdk_dart/LicenseUse/hashCode.html
@@ -154,7 +154,7 @@ like <code>HashSet</code> or <code>HashMap</code>.</p>
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/LicenseUse/noSuchMethod.html
+++ b/doc/api/tiki_sdk_dart/LicenseUse/noSuchMethod.html
@@ -162,7 +162,7 @@ external dynamic noSuchMethod(Invocation invocation);</code></pre>
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/LicenseUse/operator_equals.html
+++ b/doc/api/tiki_sdk_dart/LicenseUse/operator_equals.html
@@ -153,7 +153,7 @@ the <a href="../../tiki_sdk_dart/LicenseUse/hashCode.html">hashCode</a> method a
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/LicenseUse/runtimeType.html
+++ b/doc/api/tiki_sdk_dart/LicenseUse/runtimeType.html
@@ -129,7 +129,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/LicenseUse/toMap.html
+++ b/doc/api/tiki_sdk_dart/LicenseUse/toMap.html
@@ -130,7 +130,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/LicenseUse/toString.html
+++ b/doc/api/tiki_sdk_dart/LicenseUse/toString.html
@@ -143,7 +143,7 @@ String toString() {
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/LicenseUse/usecases.html
+++ b/doc/api/tiki_sdk_dart/LicenseUse/usecases.html
@@ -124,7 +124,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/LicenseUsecase-class.html
+++ b/doc/api/tiki_sdk_dart/LicenseUsecase-class.html
@@ -299,7 +299,7 @@ list of common enumerations or define your own using
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/LicenseUsecase/LicenseUsecase.aiTraining.html
+++ b/doc/api/tiki_sdk_dart/LicenseUsecase/LicenseUsecase.aiTraining.html
@@ -123,7 +123,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/LicenseUsecase/LicenseUsecase.analytics.html
+++ b/doc/api/tiki_sdk_dart/LicenseUsecase/LicenseUsecase.analytics.html
@@ -123,7 +123,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/LicenseUsecase/LicenseUsecase.attribution.html
+++ b/doc/api/tiki_sdk_dart/LicenseUsecase/LicenseUsecase.attribution.html
@@ -123,7 +123,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/LicenseUsecase/LicenseUsecase.custom.html
+++ b/doc/api/tiki_sdk_dart/LicenseUsecase/LicenseUsecase.custom.html
@@ -128,7 +128,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/LicenseUsecase/LicenseUsecase.distribution.html
+++ b/doc/api/tiki_sdk_dart/LicenseUsecase/LicenseUsecase.distribution.html
@@ -124,7 +124,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/LicenseUsecase/LicenseUsecase.from.html
+++ b/doc/api/tiki_sdk_dart/LicenseUsecase/LicenseUsecase.from.html
@@ -134,7 +134,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/LicenseUsecase/LicenseUsecase.personalization.html
+++ b/doc/api/tiki_sdk_dart/LicenseUsecase/LicenseUsecase.personalization.html
@@ -124,7 +124,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/LicenseUsecase/LicenseUsecase.retargeting.html
+++ b/doc/api/tiki_sdk_dart/LicenseUsecase/LicenseUsecase.retargeting.html
@@ -123,7 +123,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/LicenseUsecase/LicenseUsecase.support.html
+++ b/doc/api/tiki_sdk_dart/LicenseUsecase/LicenseUsecase.support.html
@@ -123,7 +123,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/LicenseUsecase/hashCode.html
+++ b/doc/api/tiki_sdk_dart/LicenseUsecase/hashCode.html
@@ -159,7 +159,7 @@ like <code>HashSet</code> or <code>HashMap</code>.</p>
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/LicenseUsecase/noSuchMethod.html
+++ b/doc/api/tiki_sdk_dart/LicenseUsecase/noSuchMethod.html
@@ -167,7 +167,7 @@ external dynamic noSuchMethod(Invocation invocation);</code></pre>
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/LicenseUsecase/operator_equals.html
+++ b/doc/api/tiki_sdk_dart/LicenseUsecase/operator_equals.html
@@ -158,7 +158,7 @@ the <a href="../../tiki_sdk_dart/LicenseUsecase/hashCode.html">hashCode</a> meth
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/LicenseUsecase/runtimeType.html
+++ b/doc/api/tiki_sdk_dart/LicenseUsecase/runtimeType.html
@@ -134,7 +134,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/LicenseUsecase/toString.html
+++ b/doc/api/tiki_sdk_dart/LicenseUsecase/toString.html
@@ -140,7 +140,7 @@ mainly for debugging or logging.</p>
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/LicenseUsecase/value.html
+++ b/doc/api/tiki_sdk_dart/LicenseUsecase/value.html
@@ -134,7 +134,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TikiSdk-class.html
+++ b/doc/api/tiki_sdk_dart/TikiSdk-class.html
@@ -377,7 +377,7 @@ to the <code>keyStorage</code> for <code>id</code>.
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TikiSdk/address.html
+++ b/doc/api/tiki_sdk_dart/TikiSdk/address.html
@@ -139,7 +139,7 @@ use a a different <a href="../../tiki_sdk_dart/TikiSdk/address.html">address</a>
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TikiSdk/all.html
+++ b/doc/api/tiki_sdk_dart/TikiSdk/all.html
@@ -145,7 +145,7 @@ method.</p>
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TikiSdk/getLicense.html
+++ b/doc/api/tiki_sdk_dart/TikiSdk/getLicense.html
@@ -140,7 +140,7 @@ or corresponding title record is not found.</p>
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TikiSdk/getTitle.html
+++ b/doc/api/tiki_sdk_dart/TikiSdk/getTitle.html
@@ -139,7 +139,7 @@ not found.</p>
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TikiSdk/guard.html
+++ b/doc/api/tiki_sdk_dart/TikiSdk/guard.html
@@ -188,7 +188,7 @@ if(pass) http.post(...);
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TikiSdk/hashCode.html
+++ b/doc/api/tiki_sdk_dart/TikiSdk/hashCode.html
@@ -160,7 +160,7 @@ like <code>HashSet</code> or <code>HashMap</code>.</p>
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TikiSdk/id.html
+++ b/doc/api/tiki_sdk_dart/TikiSdk/id.html
@@ -132,7 +132,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TikiSdk/init.html
+++ b/doc/api/tiki_sdk_dart/TikiSdk/init.html
@@ -197,7 +197,7 @@ verification. Configure in <a href="https://console.mytiki.com">console</a></p>
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TikiSdk/latest.html
+++ b/doc/api/tiki_sdk_dart/TikiSdk/latest.html
@@ -147,7 +147,7 @@ method.</p>
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TikiSdk/license.html
+++ b/doc/api/tiki_sdk_dart/TikiSdk/license.html
@@ -182,7 +182,7 @@ license never expires.</p>
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TikiSdk/noSuchMethod.html
+++ b/doc/api/tiki_sdk_dart/TikiSdk/noSuchMethod.html
@@ -168,7 +168,7 @@ external dynamic noSuchMethod(Invocation invocation);</code></pre>
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TikiSdk/operator_equals.html
+++ b/doc/api/tiki_sdk_dart/TikiSdk/operator_equals.html
@@ -159,7 +159,7 @@ the <a href="../../tiki_sdk_dart/TikiSdk/hashCode.html">hashCode</a> method as w
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TikiSdk/runtimeType.html
+++ b/doc/api/tiki_sdk_dart/TikiSdk/runtimeType.html
@@ -135,7 +135,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TikiSdk/title.html
+++ b/doc/api/tiki_sdk_dart/TikiSdk/title.html
@@ -159,7 +159,7 @@ the <code>TitleRecord</code> as a future reminder.</p>
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TikiSdk/toString.html
+++ b/doc/api/tiki_sdk_dart/TikiSdk/toString.html
@@ -141,7 +141,7 @@ mainly for debugging or logging.</p>
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TikiSdk/withId.html
+++ b/doc/api/tiki_sdk_dart/TikiSdk/withId.html
@@ -143,7 +143,7 @@ private key is created and registered to the <code>id</code>.</p>
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleRecord-class.html
+++ b/doc/api/tiki_sdk_dart/TitleRecord-class.html
@@ -290,7 +290,7 @@ about Title Records.</p>
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleRecord/TitleRecord.html
+++ b/doc/api/tiki_sdk_dart/TitleRecord/TitleRecord.html
@@ -125,7 +125,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleRecord/description.html
+++ b/doc/api/tiki_sdk_dart/TitleRecord/description.html
@@ -125,7 +125,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleRecord/hashCode.html
+++ b/doc/api/tiki_sdk_dart/TitleRecord/hashCode.html
@@ -155,7 +155,7 @@ like <code>HashSet</code> or <code>HashMap</code>.</p>
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleRecord/hashedPtr.html
+++ b/doc/api/tiki_sdk_dart/TitleRecord/hashedPtr.html
@@ -125,7 +125,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleRecord/id.html
+++ b/doc/api/tiki_sdk_dart/TitleRecord/id.html
@@ -125,7 +125,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleRecord/noSuchMethod.html
+++ b/doc/api/tiki_sdk_dart/TitleRecord/noSuchMethod.html
@@ -163,7 +163,7 @@ external dynamic noSuchMethod(Invocation invocation);</code></pre>
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleRecord/operator_equals.html
+++ b/doc/api/tiki_sdk_dart/TitleRecord/operator_equals.html
@@ -154,7 +154,7 @@ the <a href="../../tiki_sdk_dart/TitleRecord/hashCode.html">hashCode</a> method 
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleRecord/origin.html
+++ b/doc/api/tiki_sdk_dart/TitleRecord/origin.html
@@ -125,7 +125,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleRecord/runtimeType.html
+++ b/doc/api/tiki_sdk_dart/TitleRecord/runtimeType.html
@@ -130,7 +130,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleRecord/tags.html
+++ b/doc/api/tiki_sdk_dart/TitleRecord/tags.html
@@ -125,7 +125,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleRecord/toString.html
+++ b/doc/api/tiki_sdk_dart/TitleRecord/toString.html
@@ -136,7 +136,7 @@ mainly for debugging or logging.</p>
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleTag-class.html
+++ b/doc/api/tiki_sdk_dart/TitleTag-class.html
@@ -461,7 +461,7 @@ enumerations or define your own using <a href="../tiki_sdk_dart/TitleTag/TitleTa
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleTag/TitleTag.advertisingData.html
+++ b/doc/api/tiki_sdk_dart/TitleTag/TitleTag.advertisingData.html
@@ -146,7 +146,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleTag/TitleTag.audio.html
+++ b/doc/api/tiki_sdk_dart/TitleTag/TitleTag.audio.html
@@ -146,7 +146,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleTag/TitleTag.browsingHistory.html
+++ b/doc/api/tiki_sdk_dart/TitleTag/TitleTag.browsingHistory.html
@@ -146,7 +146,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleTag/TitleTag.coarseLocation.html
+++ b/doc/api/tiki_sdk_dart/TitleTag/TitleTag.coarseLocation.html
@@ -146,7 +146,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleTag/TitleTag.contactInfo.html
+++ b/doc/api/tiki_sdk_dart/TitleTag/TitleTag.contactInfo.html
@@ -146,7 +146,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleTag/TitleTag.contacts.html
+++ b/doc/api/tiki_sdk_dart/TitleTag/TitleTag.contacts.html
@@ -146,7 +146,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleTag/TitleTag.crashData.html
+++ b/doc/api/tiki_sdk_dart/TitleTag/TitleTag.crashData.html
@@ -146,7 +146,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleTag/TitleTag.creditInfo.html
+++ b/doc/api/tiki_sdk_dart/TitleTag/TitleTag.creditInfo.html
@@ -146,7 +146,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleTag/TitleTag.custom.html
+++ b/doc/api/tiki_sdk_dart/TitleTag/TitleTag.custom.html
@@ -150,7 +150,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleTag/TitleTag.customerSupport.html
+++ b/doc/api/tiki_sdk_dart/TitleTag/TitleTag.customerSupport.html
@@ -146,7 +146,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleTag/TitleTag.deviceId.html
+++ b/doc/api/tiki_sdk_dart/TitleTag/TitleTag.deviceId.html
@@ -146,7 +146,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleTag/TitleTag.diagnosticData.html
+++ b/doc/api/tiki_sdk_dart/TitleTag/TitleTag.diagnosticData.html
@@ -146,7 +146,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleTag/TitleTag.emailAddress.html
+++ b/doc/api/tiki_sdk_dart/TitleTag/TitleTag.emailAddress.html
@@ -146,7 +146,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleTag/TitleTag.financialInfo.html
+++ b/doc/api/tiki_sdk_dart/TitleTag/TitleTag.financialInfo.html
@@ -146,7 +146,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleTag/TitleTag.fitness.html
+++ b/doc/api/tiki_sdk_dart/TitleTag/TitleTag.fitness.html
@@ -146,7 +146,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleTag/TitleTag.from.html
+++ b/doc/api/tiki_sdk_dart/TitleTag/TitleTag.from.html
@@ -157,7 +157,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleTag/TitleTag.gameplayContent.html
+++ b/doc/api/tiki_sdk_dart/TitleTag/TitleTag.gameplayContent.html
@@ -146,7 +146,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleTag/TitleTag.health.html
+++ b/doc/api/tiki_sdk_dart/TitleTag/TitleTag.health.html
@@ -146,7 +146,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleTag/TitleTag.messages.html
+++ b/doc/api/tiki_sdk_dart/TitleTag/TitleTag.messages.html
@@ -146,7 +146,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleTag/TitleTag.paymentInfo.html
+++ b/doc/api/tiki_sdk_dart/TitleTag/TitleTag.paymentInfo.html
@@ -146,7 +146,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleTag/TitleTag.performanceData.html
+++ b/doc/api/tiki_sdk_dart/TitleTag/TitleTag.performanceData.html
@@ -146,7 +146,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleTag/TitleTag.phoneNumber.html
+++ b/doc/api/tiki_sdk_dart/TitleTag/TitleTag.phoneNumber.html
@@ -146,7 +146,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleTag/TitleTag.photoVideo.html
+++ b/doc/api/tiki_sdk_dart/TitleTag/TitleTag.photoVideo.html
@@ -146,7 +146,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleTag/TitleTag.physicalAddress.html
+++ b/doc/api/tiki_sdk_dart/TitleTag/TitleTag.physicalAddress.html
@@ -146,7 +146,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleTag/TitleTag.preciseLocation.html
+++ b/doc/api/tiki_sdk_dart/TitleTag/TitleTag.preciseLocation.html
@@ -146,7 +146,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleTag/TitleTag.productInteraction.html
+++ b/doc/api/tiki_sdk_dart/TitleTag/TitleTag.productInteraction.html
@@ -147,7 +147,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleTag/TitleTag.purchaseHistory.html
+++ b/doc/api/tiki_sdk_dart/TitleTag/TitleTag.purchaseHistory.html
@@ -146,7 +146,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleTag/TitleTag.searchHistory.html
+++ b/doc/api/tiki_sdk_dart/TitleTag/TitleTag.searchHistory.html
@@ -146,7 +146,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleTag/TitleTag.sensitiveInfo.html
+++ b/doc/api/tiki_sdk_dart/TitleTag/TitleTag.sensitiveInfo.html
@@ -146,7 +146,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleTag/TitleTag.usageData.html
+++ b/doc/api/tiki_sdk_dart/TitleTag/TitleTag.usageData.html
@@ -146,7 +146,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleTag/TitleTag.userContent.html
+++ b/doc/api/tiki_sdk_dart/TitleTag/TitleTag.userContent.html
@@ -146,7 +146,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleTag/TitleTag.userId.html
+++ b/doc/api/tiki_sdk_dart/TitleTag/TitleTag.userId.html
@@ -146,7 +146,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleTag/hashCode.html
+++ b/doc/api/tiki_sdk_dart/TitleTag/hashCode.html
@@ -182,7 +182,7 @@ like <code>HashSet</code> or <code>HashMap</code>.</p>
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleTag/noSuchMethod.html
+++ b/doc/api/tiki_sdk_dart/TitleTag/noSuchMethod.html
@@ -190,7 +190,7 @@ external dynamic noSuchMethod(Invocation invocation);</code></pre>
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleTag/operator_equals.html
+++ b/doc/api/tiki_sdk_dart/TitleTag/operator_equals.html
@@ -181,7 +181,7 @@ the <a href="../../tiki_sdk_dart/TitleTag/hashCode.html">hashCode</a> method as 
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleTag/runtimeType.html
+++ b/doc/api/tiki_sdk_dart/TitleTag/runtimeType.html
@@ -157,7 +157,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleTag/toString.html
+++ b/doc/api/tiki_sdk_dart/TitleTag/toString.html
@@ -163,7 +163,7 @@ mainly for debugging or logging.</p>
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/TitleTag/value.html
+++ b/doc/api/tiki_sdk_dart/TitleTag/value.html
@@ -157,7 +157,7 @@
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/doc/api/tiki_sdk_dart/tiki_sdk_dart-library.html
+++ b/doc/api/tiki_sdk_dart/tiki_sdk_dart-library.html
@@ -185,7 +185,7 @@ enumerations or define your own using <a href="../tiki_sdk_dart/TitleTag/TitleTa
 <footer>
   <span class="no-break">
     tiki_sdk_dart
-      2.1.2
+      2.1.3
   </span>
 
   ・🍍 mytiki.com・© Tiki inc.

--- a/lib/utils/bytes.dart
+++ b/lib/utils/bytes.dart
@@ -64,32 +64,23 @@ class Bytes {
         : BigInt.zero;
   }
 
-  /// Compares two [Uint8List]s by comparing 8 bytes at a time.
-  static bool memEquals(Uint8List bytes1, Uint8List bytes2) {
-    if (identical(bytes1, bytes2)) {
-      return true;
+  /// Compares two [Uint8List]s for equality
+  /// From: https://api.flutter.dev/flutter/foundation/listEquals.html.
+  static bool memEquals(Uint8List? a, Uint8List? b) {
+    if (a == null) {
+      return b == null;
     }
-
-    if (bytes1.lengthInBytes != bytes2.lengthInBytes) {
+    if (b == null || a.length != b.length) {
       return false;
     }
-
-    var numWords = bytes1.lengthInBytes ~/ 8;
-    var words1 = bytes1.buffer.asUint64List(0, numWords);
-    var words2 = bytes2.buffer.asUint64List(0, numWords);
-
-    for (var i = 0; i < words1.length; i += 1) {
-      if (words1[i] != words2[i]) {
+    if (identical(a, b)) {
+      return true;
+    }
+    for (int index = 0; index < a.length; index += 1) {
+      if (a[index] != b[index]) {
         return false;
       }
     }
-
-    for (var i = words1.lengthInBytes; i < bytes1.lengthInBytes; i += 1) {
-      if (bytes1[i] != bytes2[i]) {
-        return false;
-      }
-    }
-
     return true;
   }
 

--- a/lib/utils/compact_size.dart
+++ b/lib/utils/compact_size.dart
@@ -58,9 +58,11 @@ class CompactSize {
       Uint32List uint32list = Uint32List.fromList([size]);
       byteList.add(uint32list.buffer.asUint8List());
     } else {
-      byteList.addByte(255);
-      Uint64List uint64list = Uint64List.fromList([size]);
-      byteList.add(uint64list.buffer.asUint8List());
+      throw UnsupportedError(
+          ">Uint32 length sizes are not unsupported. Pick a size under 4,294,967,295 bytes");
+      // byteList.addByte(255);
+      // Uint64List uint64list = Uint64List.fromList([size]);
+      // byteList.add(uint64list.buffer.asUint8List());
     }
     return byteList.toBytes();
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: tiki_sdk_dart
 description: Create and enforce immutable data licensing records client-side. The core-implementation of TIKI's client-side infrastructure.
-version: 2.1.2
+version: 2.1.3
 homepage: https://mytiki.com
 documentation: https://docs.mytiki.com/docs/sdk-overview
 repository: https://github.com/tiki/tiki-sdk-dart


### PR DESCRIPTION
- We don't support byte array's over Uint32 in length
- Replace our memEquals function with Flutter's listEquals